### PR TITLE
1 refactor: migrate from shell scripts to ansible

### DIFF
--- a/ansible/group_vars/all/directories_list_all.yml
+++ b/ansible/group_vars/all/directories_list_all.yml
@@ -1,0 +1,5 @@
+directories_list_all:
+  - { path: '/usr/local/admin/bin', owner: 'root', group: 'root', mode: '0700' }
+  - { path: '/usr/local/admin/backup', owner: 'root', group: 'root', mode: '0700' }
+  - { path: '/usr/local/admin/etc', owner: 'root', group: 'root', mode: '0700' }
+  - { path: '/etc/ansible/facts.d', owner: 'root', group: 'root', mode: '0700' }

--- a/ansible/playbooks/base.yml
+++ b/ansible/playbooks/base.yml
@@ -1,0 +1,14 @@
+---
+
+- hosts: all
+  gather_facts: yes
+  #  remote_user: ansible
+
+  roles:
+    # Other roles could depend on this role. Keep it first.
+    - { role: ansible-directories,            tags: directories }
+    - { role: ansible-cloud-init,             tags: cloud-init }
+    # https://github.com/RedHatGov/ansible-role-800-53, forked and modified for CentOS
+    # Keep this role second. It does *a lot* and we don't want it to overwrite our changes
+    - { role: ansible-800-53,                 tags: 800-53 }
+    # Put all other roles after this line


### PR DESCRIPTION
Shell scripts are still in place, but will be removed at a later date.

Update your ~/.occs_packer_variables. Some have changed and a few others
added. OCCS_ANSIBLE_PUB_KEY is not functional yet.

ansible roles will need to be pulled down individuall and put in
./ansible/roles for the build to complete.